### PR TITLE
Add quiz casestudy

### DIFF
--- a/.impeccable/critique/2026-07-03T04-44-31Z__src-case-studies-yubico-yubicocasestudy-tsx.md
+++ b/.impeccable/critique/2026-07-03T04-44-31Z__src-case-studies-yubico-yubicocasestudy-tsx.md
@@ -1,0 +1,83 @@
+---
+target: src/case-studies/yubico/YubicoCaseStudy.tsx
+total_score: 28
+p0_count: 0
+p1_count: 1
+timestamp: 2026-07-03T04-44-31Z
+slug: src-case-studies-yubico-yubicocasestudy-tsx
+---
+## Design Health Score
+
+| # | Heuristic | Score | Key Issue |
+|---|-----------|-------|-----------|
+| 1 | Visibility of System Status | 3 | Static page is clear; footer links provide navigation, no process state needed. |
+| 2 | Match System / Real World | 3 | Product-finder story is understandable; “Skilled” and “Customer Success” could be more human and explicit. |
+| 3 | User Control and Freedom | 3 | Back-to-projects and live quiz links are clear; no local table of contents or jump aid for scanners. |
+| 4 | Consistency and Standards | 3 | Strong consistency with case-study system; Yubico local styling is restrained. |
+| 5 | Error Prevention | 3 | Mostly not applicable for static content; unsupported metric guardrails are handled in the outcome note. |
+| 6 | Recognition Rather Than Recall | 3 | Headings and path cards explain the story; sequence numerals are visual only. |
+| 7 | Flexibility and Efficiency of Use | 2 | Recruiters can scan, but technical readers have no fast summary of decisions beyond the list. |
+| 8 | Aesthetic and Minimalist Design | 3 | Quiet and credible, though several sections fall into similar card-panel rhythm. |
+| 9 | Error Recovery | 3 | Mostly not applicable; navigation exits are present. |
+| 10 | Help and Documentation | 2 | Technical detail is intentionally incomplete because source review is pending. |
+| **Total** | | **28/40** | **Good foundation** |
+
+## Anti-Patterns Verdict
+
+**LLM assessment**: It does not scream AI-made. The restraint matches the portfolio brand better than a heavy case-study spectacle would. The main AI-adjacent tell is structural: card grid, muted panels, outcome callout, learned paragraph. It is competent and calm, but it needs one sharper artifact of engineering judgment to feel more authored.
+
+**Deterministic scan**: `detect.mjs --json src/case-studies/yubico/YubicoCaseStudy.tsx` returned `[]`. No detector findings.
+
+**Visual overlays**: Browser automation and overlay injection are unavailable in this session, so there is no reliable user-visible overlay. Fallback signal is source review plus deterministic CLI scan.
+
+## Overall Impression
+
+This is a solid, honest case-study shell. It respects the role boundary and avoids unsupported conversion claims. The biggest opportunity is to make the frontend engineering contribution feel more concrete without inventing details: right now the page tells me you implemented the quiz, but only the technical list and Cypress note prove it.
+
+## What's Working
+
+1. The role section is calibrated. `YubicoCaseStudy.tsx:169` through `176` is honest about joining after structure and visual direction were underway, while still claiming frontend ownership.
+2. The four-path structure is readable. `YubicoCaseStudy.tsx:26` through `43` keeps the product decision model simple, which matches the story.
+3. The outcome disclaimer is responsible. `YubicoCaseStudy.tsx:272` through `279` states the only supported metric and blocks purchase attribution.
+
+## Priority Issues
+
+**[P1] Technical credibility is still deferred**
+- **Why it matters**: For a frontend portfolio, the technical section is where a technical lead decides whether the work sounds real. The Lorem ipsum placeholder at `YubicoCaseStudy.tsx:258` through `262` currently breaks trust.
+- **Fix**: Replace it after source-code review with 2 to 4 verified implementation details: state shape, branching rules, WordPress integration boundary, Cypress path coverage, or accessibility constraints. Keep it specific and short.
+- **Suggested command**: `$impeccable clarify`
+
+**[P2] Path labels risk sounding like user grading**
+- **Why it matters**: “Novice / Intermediate / Skilled” at `YubicoCaseStudy.tsx:28`, `32`, and `36` explains branching, but “Novice” and “Skilled” can read like judging the visitor rather than meeting their context.
+- **Fix**: If these are not locked product labels, rewrite them as customer-state labels: “New to security keys,” “Some setup context,” “Know my requirements,” and “Buying for a team.” If they are real quiz labels, keep them but add a short sentence that frames them as starting points.
+- **Suggested command**: `$impeccable clarify`
+
+**[P2] Sequence numbers are visual-only polish**
+- **Why it matters**: The card numbers are generated in CSS at `YubicoCaseStudy.module.css:87` through `105`. They help sighted users see sequence, but screen readers may not announce generated content consistently. This is not a blocker because titles are clear, but the visible sequence is not semantic.
+- **Fix**: If order matters, render the number in JSX with `aria-hidden="true"` plus a semantic list wrapper, or use an ordered list styled as cards. If order does not matter, keep titles as the source of meaning and treat numbers as decorative.
+- **Suggested command**: `$impeccable audit`
+
+**[P2] The page is calm, but a little too evenly calm**
+- **Why it matters**: Ignoring the media placeholders, the current experience has one visual beat: bordered cards and panels. For a portfolio, craft is the proof. The page could use one stronger authored moment that is not fake UI and not a custom hero.
+- **Fix**: Once real assets are available, let the entry-path product screenshot carry the visual peak. Before assets, a small verified implementation note or code-adjacent rule table could create a more distinctive engineering moment.
+- **Suggested command**: `$impeccable layout`
+
+## Persona Red Flags
+
+**Hiring manager scanning in 20 seconds**: The high-level story is clear, but the section order delays concrete proof. They understand “frontend engineer,” yet may not remember a signature contribution beyond “built the quiz.”
+
+**Technical lead validating depth**: The technical list is directionally useful, but the Lorem ipsum placeholder blocks a serious read. They need one verified implementation detail before this feels complete.
+
+**Sam, accessibility-dependent user**: Heading hierarchy is sound and no hover-only behavior appears. Main risk is the visual-only CSS sequence numbers on path cards if the sequence is meant to be meaningful.
+
+## Minor Observations
+
+- `YubicoCaseStudy.tsx:128` through `139`: a one-item metadata `dl` is semantically valid, but visually it may feel heavier than the value of “Company: Yubico.”
+- `YubicoCaseStudy.tsx:220` through `229`: “Customer Success handoff” is clear enough for a case study, but if the public audience includes non-SaaS readers, “contact Customer Success” may be plainer.
+- `YubicoCaseStudy.module.css:68` through `85`: border plus a very broad, faint shadow is subtle enough, but it sits near the ghost-card pattern. Keep it restrained.
+
+## Questions to Consider
+
+- What is the one implementation decision only you could explain from this project?
+- Are “Novice,” “Intermediate,” and “Skilled” actual product labels, or are they case-study shorthand?
+- Should this page optimize for recruiter scan speed, technical lead credibility, or a balance between both?

--- a/src/case-studies/components/CaseStudyLayout.tsx
+++ b/src/case-studies/components/CaseStudyLayout.tsx
@@ -241,7 +241,7 @@ const ClosingCopy = styled.p`
   line-height: 1.7;
 `;
 
-const MosaicClosing = styled(Closing)`
+const CompactClosing = styled(Closing)`
   display: flex;
   flex-wrap: wrap;
   align-items: center;
@@ -309,7 +309,7 @@ const ExternalLink = styled.a`
   }
 `;
 
-const MosaicSecondaryLink = styled(Link)`
+const CompactSecondaryLink = styled(Link)`
   display: inline-flex;
   align-items: center;
   gap: 0.35rem;
@@ -337,7 +337,7 @@ const MosaicSecondaryLink = styled(Link)`
   }
 `;
 
-const MosaicPrimaryLink = styled.a`
+const CompactPrimaryLink = styled.a`
   display: inline-flex;
   align-items: center;
   gap: 0.35rem;
@@ -395,7 +395,9 @@ export default function CaseStudyLayout({
   ].filter(Boolean) as Array<{ label: string; value: string | number }>;
   const useCaseStudyGoldEyebrow = eyebrow === 'Product case study';
   const isMosaicCaseStudy = title === 'Mosaic';
-  const mosaicLiveLink = links.find((link) => 'url' in link);
+  const isYubicoCaseStudy = slug === 'yubico-quiz';
+  const compactLiveLink = links.find((link) => 'url' in link);
+  const compactLiveLabel = isMosaicCaseStudy ? 'Get Mosaic' : 'View live quiz';
 
   const trackCaseStudyLinkClick = (link: ProjectLink) => {
     const analyticsEvent = getProjectLinkAnalytics({
@@ -469,27 +471,29 @@ export default function CaseStudyLayout({
 
       <Content>{children}</Content>
 
-      {isMosaicCaseStudy && mosaicLiveLink && 'url' in mosaicLiveLink ? (
-        <MosaicClosing>
-          <MosaicSecondaryLink to="/projects">
+      {(isMosaicCaseStudy || isYubicoCaseStudy) &&
+      compactLiveLink &&
+      'url' in compactLiveLink ? (
+        <CompactClosing>
+          <CompactSecondaryLink to="/projects">
             <ArrowLeft size={16} weight="bold" />
             Back to projects
-          </MosaicSecondaryLink>
-          <MosaicPrimaryLink
-            href={mosaicLiveLink.url}
+          </CompactSecondaryLink>
+          <CompactPrimaryLink
+            href={compactLiveLink.url}
             target="_blank"
             rel="noopener noreferrer"
             onClick={() =>
               trackCaseStudyLinkClick({
-                ...mosaicLiveLink,
-                label: 'Get Mosaic',
+                ...compactLiveLink,
+                label: compactLiveLabel,
               })
             }
           >
-            Get Mosaic
+            {compactLiveLabel}
             <ArrowUpRight size={14} weight="bold" />
-          </MosaicPrimaryLink>
-        </MosaicClosing>
+          </CompactPrimaryLink>
+        </CompactClosing>
       ) : (
         <Closing>
           <ClosingCopy>

--- a/src/case-studies/index.ts
+++ b/src/case-studies/index.ts
@@ -1,10 +1,16 @@
 import MosaicCaseStudy from './mosaic/MosaicCaseStudy';
 import { mosaicCaseStudyMeta } from './mosaic/mosaicCaseStudyData';
+import YubicoCaseStudy from './yubico/YubicoCaseStudy';
+import { yubicoCaseStudyMeta } from './yubico/yubicoCaseStudyData';
 
 export const caseStudies = {
   mosaic: {
     ...mosaicCaseStudyMeta,
     Component: MosaicCaseStudy,
+  },
+  'yubico-quiz': {
+    ...yubicoCaseStudyMeta,
+    Component: YubicoCaseStudy,
   },
 } as const;
 

--- a/src/case-studies/yubico/YubicoCaseStudy.module.css
+++ b/src/case-studies/yubico/YubicoCaseStudy.module.css
@@ -11,40 +11,6 @@
   );
 }
 
-.introMeta {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 1px;
-  overflow: hidden;
-  margin: 0 0 1.35rem;
-  padding: 0;
-  border: 1px solid var(--yubico-border);
-  border-radius: 12px;
-  background-color: var(--yubico-border);
-}
-
-.introMetaItem {
-  display: grid;
-  gap: 0.25rem;
-  padding: 0.85rem 0.95rem;
-  background-color: var(--yubico-bg);
-}
-
-.introMetaLabel {
-  color: var(--yubico-muted);
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-}
-
-.introMetaValue {
-  color: var(--yubico-text);
-  font-size: 0.95rem;
-  font-weight: 600;
-  line-height: 1.45;
-}
-
 .pathLead {
   max-width: 62ch;
   color: var(--yubico-muted);

--- a/src/case-studies/yubico/YubicoCaseStudy.module.css
+++ b/src/case-studies/yubico/YubicoCaseStudy.module.css
@@ -1,0 +1,371 @@
+.caseStudyScope {
+  --placeholder-line: color-mix(
+    in oklch,
+    var(--yubico-border),
+    var(--yubico-accent) 34%
+  );
+  --placeholder-surface: color-mix(
+    in oklch,
+    var(--yubico-bg),
+    var(--yubico-primary) 2.5%
+  );
+}
+
+.introMeta {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1px;
+  overflow: hidden;
+  margin: 0 0 1.35rem;
+  padding: 0;
+  border: 1px solid var(--yubico-border);
+  border-radius: 12px;
+  background-color: var(--yubico-border);
+}
+
+.introMetaItem {
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.85rem 0.95rem;
+  background-color: var(--yubico-bg);
+}
+
+.introMetaLabel {
+  color: var(--yubico-muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.introMetaValue {
+  color: var(--yubico-text);
+  font-size: 0.95rem;
+  font-weight: 600;
+  line-height: 1.45;
+}
+
+.pathLead {
+  max-width: 62ch;
+  color: var(--yubico-muted);
+}
+
+.pathGrid {
+  counter-reset: finder-path;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.75rem;
+  margin-top: 0.95rem;
+}
+
+@media (min-width: 680px) {
+  .pathGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.pathCard {
+  position: relative;
+  counter-increment: finder-path;
+  display: grid;
+  align-content: start;
+  gap: 0.65rem;
+  min-height: 10rem;
+  padding: 1rem;
+  border: 1px solid var(--yubico-border);
+  border-radius: 12px;
+  background: linear-gradient(
+      180deg,
+      color-mix(in oklch, var(--yubico-bg), var(--yubico-primary) 3%),
+      var(--yubico-bg)
+    ),
+    var(--yubico-bg);
+}
+
+.pathCard::before {
+  display: inline-grid;
+  width: 1.75rem;
+  height: 1.75rem;
+  margin-bottom: 0.15rem;
+  border: 1px solid var(--placeholder-line);
+  border-radius: 999px;
+  color: var(--yubico-accent-text);
+  background-color: color-mix(
+    in oklch,
+    var(--yubico-bg),
+    var(--yubico-accent) 8%
+  );
+  content: counter(finder-path, decimal-leading-zero);
+  font-size: 0.66rem;
+  font-weight: 800;
+  line-height: 1;
+  place-items: center;
+}
+
+.pathTitle {
+  color: var(--yubico-text);
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.pathText {
+  color: var(--yubico-muted);
+  font-size: 0.92rem;
+  line-height: 1.65;
+}
+
+.placeholderFigure {
+  display: grid;
+  gap: 0.75rem;
+  margin: 1.35rem 0 0;
+}
+
+.placeholderFigure[data-size='medium'] {
+  margin-top: 0;
+}
+
+.placeholderFrame {
+  position: relative;
+  isolation: isolate;
+  display: grid;
+  overflow: hidden;
+  aspect-ratio: 16 / 9;
+  min-height: 12rem;
+  padding: clamp(1rem, 3vw, 1.5rem);
+  border: 1px dashed var(--placeholder-line);
+  border-radius: 14px;
+  background: repeating-linear-gradient(
+      90deg,
+      transparent 0,
+      transparent 2.4rem,
+      color-mix(in oklch, var(--yubico-border), transparent 58%) 2.45rem
+    ),
+    linear-gradient(
+      135deg,
+      color-mix(in oklch, var(--placeholder-surface), var(--yubico-accent) 4%),
+      var(--yubico-bg)
+    ),
+    var(--yubico-bg);
+  box-shadow: inset 0 0 0 1px
+    color-mix(in oklch, var(--yubico-bg), var(--yubico-text) 4%);
+  place-items: center;
+  text-align: center;
+}
+
+.placeholderFigure[data-size='wide'] .placeholderFrame {
+  aspect-ratio: 16 / 8.4;
+}
+
+.placeholderContent {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 0.45rem;
+  width: min(100%, 32rem);
+  padding: clamp(1rem, 3vw, 1.35rem);
+  border: 1px solid color-mix(in oklch, var(--yubico-border), transparent 12%);
+  border-radius: 12px;
+  background-color: color-mix(in oklch, var(--yubico-bg), transparent 4%);
+  box-shadow: 0 20px 55px -46px var(--yubico-shadow);
+}
+
+.placeholderLabel {
+  color: var(--yubico-accent-text);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.11em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.placeholderFormat {
+  color: var(--yubico-text);
+  font-size: clamp(1.15rem, 2.4vw, 1.5rem);
+  font-weight: 650;
+  line-height: 1.25;
+}
+
+.placeholderPurpose {
+  color: var(--yubico-muted);
+  font-size: 0.95rem;
+  line-height: 1.65;
+}
+
+.placeholderCaption {
+  color: var(--yubico-muted);
+  font-size: 0.85rem;
+  line-height: 1.6;
+}
+
+.nextStepLayout {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.2rem;
+  align-items: start;
+}
+
+.routeList {
+  counter-reset: route-step;
+  display: grid;
+  gap: 1px;
+  overflow: hidden;
+  margin: 0;
+  padding: 0;
+  border: 1px solid var(--yubico-border);
+  border-radius: 14px;
+  background-color: var(--yubico-border);
+  list-style: none;
+}
+
+.routeItem {
+  counter-increment: route-step;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: start;
+  gap: 0.75rem;
+  padding: 0.9rem 1rem;
+  background-color: var(--yubico-bg);
+}
+
+.routeItem::before {
+  display: inline-grid;
+  width: 1.65rem;
+  height: 1.65rem;
+  border: 1px solid var(--placeholder-line);
+  border-radius: 999px;
+  color: var(--yubico-accent-text);
+  background-color: color-mix(
+    in oklch,
+    var(--yubico-bg),
+    var(--yubico-accent) 7%
+  );
+  content: counter(route-step);
+  font-size: 0.72rem;
+  font-weight: 800;
+  line-height: 1;
+  place-items: center;
+}
+
+.routeContent {
+  min-width: 0;
+}
+
+.routeLabel {
+  display: block;
+  color: var(--yubico-text);
+  font-size: 0.88rem;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.routeText {
+  display: block;
+  margin-top: 0.2rem;
+  color: var(--yubico-muted);
+  font-size: 0.86rem;
+  line-height: 1.55;
+}
+
+@media (min-width: 960px) {
+  .nextStepLayout {
+    grid-template-columns: minmax(0, 0.86fr) minmax(18rem, 0.72fr);
+    gap: 1.5rem;
+  }
+}
+
+.questionLayout {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.25rem;
+  align-items: start;
+}
+
+@media (min-width: 960px) {
+  .questionLayout {
+    grid-template-columns: minmax(0, 0.72fr) minmax(21rem, 1fr);
+    gap: 1.5rem;
+  }
+
+  .questionLayout .placeholderFigure {
+    margin-top: 0;
+  }
+}
+
+.mediaPair {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.1rem;
+  margin-top: 1.5rem;
+}
+
+@media (min-width: 760px) {
+  .mediaPair {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.technicalPanel {
+  display: grid;
+  gap: clamp(1rem, 2.5vw, 1.35rem);
+  padding: clamp(1rem, 3vw, 1.5rem);
+  border: 1px solid var(--yubico-border);
+  border-radius: 14px;
+  background: linear-gradient(
+      180deg,
+      color-mix(in oklch, var(--yubico-bg), var(--yubico-primary) 3%),
+      var(--yubico-bg)
+    ),
+    var(--yubico-bg);
+}
+
+.technicalList {
+  display: grid;
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.technicalItem {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.55rem;
+  padding: 0.78rem 0;
+  border-bottom: 1px solid var(--yubico-border);
+  color: var(--yubico-muted);
+  font-size: 0.95rem;
+  line-height: 1.65;
+}
+
+.technicalItem:first-child {
+  padding-top: 0;
+}
+
+.technicalItem:last-child {
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+
+.technicalItem::before {
+  width: 0.38rem;
+  height: 0.38rem;
+  margin-top: 0.66rem;
+  border-radius: 999px;
+  background-color: var(--yubico-accent-text);
+  content: '';
+}
+
+.temporaryNote {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--yubico-border);
+  color: var(--yubico-muted);
+  font-size: 0.92rem;
+  line-height: 1.7;
+}
+
+.outcomeBlock {
+  display: grid;
+  gap: 1rem;
+}

--- a/src/case-studies/yubico/YubicoCaseStudy.tsx
+++ b/src/case-studies/yubico/YubicoCaseStudy.tsx
@@ -1,0 +1,331 @@
+import React from 'react';
+import { useTheme } from 'styled-components';
+import CaseStudyCallout from '../components/CaseStudyCallout';
+import CaseStudyLayout from '../components/CaseStudyLayout';
+import CaseStudySection from '../components/CaseStudySection';
+import {
+  CASE_STUDY_GOLD,
+  getCaseStudyGoldTextColor,
+} from '../components/caseStudyColorTokens';
+import { yubicoCaseStudyMeta } from './yubicoCaseStudyData';
+import styles from './YubicoCaseStudy.module.css';
+
+type YubicoThemeStyle = React.CSSProperties & {
+  '--yubico-bg': string;
+  '--yubico-text': string;
+  '--yubico-muted': string;
+  '--yubico-border': string;
+  '--yubico-shadow': string;
+  '--yubico-accent': string;
+  '--yubico-accent-text': string;
+  '--yubico-primary': string;
+};
+
+const introMetaItems = [{ label: 'Company', value: 'Yubico' }] as const;
+
+const pathCards = [
+  {
+    title: 'Novice',
+    text: 'A shorter route for people getting started with security keys.',
+  },
+  {
+    title: 'Intermediate',
+    text: 'A more focused path for people with some familiarity who need help narrowing their options.',
+  },
+  {
+    title: 'Skilled',
+    text: 'More specific questions for people who already understand their setup and requirements.',
+  },
+  {
+    title: 'Business',
+    text: 'When the selected quantity passes the business threshold, the quiz can shift from product selection to Customer Success.',
+  },
+] as const;
+
+const nextStepRoutes = [
+  {
+    label: 'Answer pattern',
+    text: 'Responses narrow the flow around experience level, setup, and purchase context.',
+  },
+  {
+    label: 'Product recommendation',
+    text: 'Individual buyers can reach a relevant security-key recommendation.',
+  },
+  {
+    label: 'Business handoff',
+    text: 'Larger team purchases can move from product guidance to Customer Success.',
+  },
+] as const;
+
+const technicalPoints = [
+  'Path-specific question sets for different experience levels and purchase contexts.',
+  'Conditional frontend logic that moves people through the appropriate questions and next steps.',
+  'Reusable question, answer, progress, and explanatory-content patterns.',
+  'Responsive and accessible frontend implementation.',
+  'React application integrated into the marketing site through the company’s existing custom WordPress plugin pattern.',
+  'Cypress coverage added later to protect key quiz paths.',
+] as const;
+
+type MediaPlaceholderProps = {
+  format: string;
+  purpose: string;
+  size?: 'wide' | 'medium';
+};
+
+type YubicoSectionProps = React.ComponentProps<typeof CaseStudySection> & {
+  themeStyle: YubicoThemeStyle;
+};
+
+function useYubicoThemeStyle(): YubicoThemeStyle {
+  const theme = useTheme();
+
+  return {
+    '--yubico-bg': theme.colors.background,
+    '--yubico-text': theme.colors['default-text'],
+    '--yubico-muted': theme.colors['secondary-text'],
+    '--yubico-border': theme.colors.border,
+    '--yubico-shadow': theme.colors.boxShadow,
+    '--yubico-accent': CASE_STUDY_GOLD,
+    '--yubico-accent-text': getCaseStudyGoldTextColor(
+      theme.colors['default-text'],
+    ),
+    '--yubico-primary': theme.colors.primary,
+  };
+}
+
+function YubicoSection({
+  themeStyle,
+  children,
+  ...sectionProps
+}: YubicoSectionProps) {
+  return (
+    <div className={styles.caseStudyScope} style={themeStyle}>
+      <CaseStudySection {...sectionProps}>{children}</CaseStudySection>
+    </div>
+  );
+}
+
+function MediaPlaceholder({
+  format,
+  purpose,
+  size = 'wide',
+}: MediaPlaceholderProps) {
+  return (
+    <figure className={styles.placeholderFigure} data-size={size}>
+      <div className={styles.placeholderFrame}>
+        <div className={styles.placeholderContent}>
+          <p className={styles.placeholderLabel}>Media placeholder</p>
+          <p className={styles.placeholderFormat}>{format}</p>
+          <p className={styles.placeholderPurpose}>{purpose}</p>
+        </div>
+      </div>
+      <figcaption className={styles.placeholderCaption}>
+        Temporary media slot. Replace this figure with verified project imagery
+        when the final asset is available.
+      </figcaption>
+    </figure>
+  );
+}
+
+export default function YubicoCaseStudy() {
+  const yubicoThemeStyle = useYubicoThemeStyle();
+
+  return (
+    <CaseStudyLayout
+      title={yubicoCaseStudyMeta.title}
+      slug={yubicoCaseStudyMeta.slug}
+      eyebrow={yubicoCaseStudyMeta.eyebrow}
+      summary={yubicoCaseStudyMeta.summary}
+      role={yubicoCaseStudyMeta.role}
+      tech={yubicoCaseStudyMeta.tech}
+      links={yubicoCaseStudyMeta.links}
+    >
+      <YubicoSection title="Overview" themeStyle={yubicoThemeStyle}>
+        <dl
+          className={styles.introMeta}
+          aria-label="Yubico case study metadata"
+        >
+          {introMetaItems.map((item) => (
+            <div className={styles.introMetaItem} key={item.label}>
+              <dt className={styles.introMetaLabel}>{item.label}</dt>
+              <dd className={styles.introMetaValue}>{item.value}</dd>
+            </div>
+          ))}
+        </dl>
+        <p>
+          Yubico’s product finder helps people choose a security key without
+          requiring everyone to begin with the same level of technical
+          knowledge. Visitors choose a starting point based on their familiarity
+          and purchase context, answer a tailored set of questions, and receive
+          a product recommendation or a clear next step.
+        </p>
+      </YubicoSection>
+
+      <YubicoSection
+        title="Why rebuild it"
+        spacing="compact"
+        themeStyle={yubicoThemeStyle}
+      >
+        <p>
+          The project replaced an older quiz that was harder to follow and did
+          not create a clear enough path from someone’s needs to a product
+          recommendation or business handoff. The goal was to help beginners
+          reach an answer faster, ask more relevant questions for experienced
+          buyers, and give larger business purchases a clearer route to contact
+          Customer Success.
+        </p>
+      </YubicoSection>
+
+      <YubicoSection
+        title="My role"
+        spacing="compact"
+        themeStyle={yubicoThemeStyle}
+      >
+        <p>
+          The broader quiz structure and visual direction were already underway
+          when I joined. I worked closely with UX and design to clarify
+          incomplete rules, work through unclear questions and states, and turn
+          the flow into a responsive, accessible React experience. I owned the
+          frontend implementation, conditional flow logic, responsive behavior,
+          and accessibility, then later added Cypress coverage for key quiz
+          paths.
+        </p>
+      </YubicoSection>
+
+      <YubicoSection
+        title="One product finder, four paths"
+        spacing="spacious"
+        themeStyle={yubicoThemeStyle}
+      >
+        <p className={styles.pathLead}>
+          The labels stay familiar to the quiz, but each one acts as a starting
+          point for how much guidance someone needs.
+        </p>
+        <div className={styles.pathGrid}>
+          {pathCards.map((path) => (
+            <article className={styles.pathCard} key={path.title}>
+              <h3 className={styles.pathTitle}>{path.title}</h3>
+              <p className={styles.pathText}>{path.text}</p>
+            </article>
+          ))}
+        </div>
+        <MediaPlaceholder
+          format="GIF or screenshot"
+          purpose="Show the entry-path selection screen with Novice, Intermediate, Skilled, and Business options."
+        />
+      </YubicoSection>
+
+      <YubicoSection
+        title="Helping people answer technical questions"
+        spacing="spacious"
+        themeStyle={yubicoThemeStyle}
+      >
+        <div className={styles.questionLayout}>
+          <p>
+            Each path uses a different set of questions, so beginners are not
+            forced through the same level of detail as experienced buyers.
+            Supporting information sits alongside the flow to explain
+            terminology, clarify what a question is asking, and provide relevant
+            Yubico context when it helps someone answer with more confidence.
+          </p>
+          <MediaPlaceholder
+            format="Screenshot or GIF"
+            purpose="Show a quiz question with the supporting information panel visible."
+          />
+        </div>
+      </YubicoSection>
+
+      <YubicoSection
+        title="From answers to the right next step"
+        spacing="spacious"
+        themeStyle={yubicoThemeStyle}
+      >
+        <div className={styles.nextStepLayout}>
+          <p>
+            Answers guide people toward a relevant security-key recommendation
+            instead of sending every visitor through one generic flow. For
+            business buyers with larger purchase needs, the experience can move
+            from product guidance to Customer Success at the appropriate point.
+          </p>
+          <ol className={styles.routeList}>
+            {nextStepRoutes.map((route) => (
+              <li className={styles.routeItem} key={route.label}>
+                <span className={styles.routeContent}>
+                  <span className={styles.routeLabel}>{route.label}</span>
+                  <span className={styles.routeText}>{route.text}</span>
+                </span>
+              </li>
+            ))}
+          </ol>
+        </div>
+        <div className={styles.mediaPair}>
+          <MediaPlaceholder
+            format="Screenshot or GIF"
+            purpose="Business purchase handoff."
+            size="medium"
+          />
+          <MediaPlaceholder
+            format="Screenshot"
+            purpose="Product recommendation screen."
+            size="medium"
+          />
+        </div>
+      </YubicoSection>
+
+      <YubicoSection
+        title="Technical approach"
+        spacing="spacious"
+        themeStyle={yubicoThemeStyle}
+      >
+        <div className={styles.technicalPanel}>
+          <ul className={styles.technicalList}>
+            {technicalPoints.map((point) => (
+              <li className={styles.technicalItem} key={point}>
+                {point}
+              </li>
+            ))}
+          </ul>
+          <p className={styles.temporaryNote}>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Temporary
+            implementation detail placeholder for source-code-specific rules
+            that need to be verified before they are described publicly.
+          </p>
+        </div>
+      </YubicoSection>
+
+      <YubicoSection
+        title="Outcome"
+        spacing="spacious"
+        themeStyle={yubicoThemeStyle}
+      >
+        <div className={styles.outcomeBlock}>
+          <CaseStudyCallout label="Outcome">
+            At a later point, internal tracking showed that 60% of people who
+            completed the quiz continued to the e-commerce site.
+          </CaseStudyCallout>
+          <p>
+            This only reflects quiz completers who reached the store. It does
+            not attribute purchases, and it is not a metric for all site
+            visitors.
+          </p>
+        </div>
+      </YubicoSection>
+
+      <YubicoSection
+        title="What I learned"
+        spacing="spacious"
+        themeStyle={yubicoThemeStyle}
+      >
+        <p>
+          The most useful simplification was not removing detail everywhere. It
+          was letting beginners reach a starting recommendation quickly while
+          keeping the questions more specific for people who already knew what
+          they needed. The project reinforced that a product finder is not just
+          a multi-step form. The order of questions, amount of explanation, and
+          quality of each branch all shape whether someone feels guided or
+          overwhelmed.
+        </p>
+      </YubicoSection>
+    </CaseStudyLayout>
+  );
+}

--- a/src/case-studies/yubico/YubicoCaseStudy.tsx
+++ b/src/case-studies/yubico/YubicoCaseStudy.tsx
@@ -21,8 +21,6 @@ type YubicoThemeStyle = React.CSSProperties & {
   '--yubico-primary': string;
 };
 
-const introMetaItems = [{ label: 'Company', value: 'Yubico' }] as const;
-
 const pathCards = [
   {
     title: 'Novice',
@@ -141,17 +139,6 @@ export default function YubicoCaseStudy() {
       links={yubicoCaseStudyMeta.links}
     >
       <YubicoSection title="Overview" themeStyle={yubicoThemeStyle}>
-        <dl
-          className={styles.introMeta}
-          aria-label="Yubico case study metadata"
-        >
-          {introMetaItems.map((item) => (
-            <div className={styles.introMetaItem} key={item.label}>
-              <dt className={styles.introMetaLabel}>{item.label}</dt>
-              <dd className={styles.introMetaValue}>{item.value}</dd>
-            </div>
-          ))}
-        </dl>
         <p>
           Yubico’s product finder helps people choose a security key without
           requiring everyone to begin with the same level of technical

--- a/src/case-studies/yubico/yubicoCaseStudyData.ts
+++ b/src/case-studies/yubico/yubicoCaseStudyData.ts
@@ -1,0 +1,18 @@
+import type { CaseStudyMeta } from '../types';
+
+export const yubicoCaseStudyMeta: CaseStudyMeta = {
+  slug: 'yubico-quiz',
+  title: 'Yubico Product Finder Quiz',
+  eyebrow: 'Product case study',
+  summary:
+    'A guided product finder that helps people choose the right security key based on their experience, setup, and purchase needs.',
+  role: 'Frontend Engineer',
+  tech: 'React, TypeScript, Tailwind, WordPress',
+  links: [
+    {
+      label: 'Live Site',
+      url: 'https://www.yubico.com/quiz/',
+      type: 'web',
+    },
+  ],
+};

--- a/src/portfolio-data.ts
+++ b/src/portfolio-data.ts
@@ -64,28 +64,28 @@ export const projects: Project[] = [
       },
     ],
   },
-  {
-    title: 'Product Finder Quiz',
-    image:
-      'https://los-project-images.s3.us-east-1.amazonaws.com/portfolio/mosaic.webp',
-    description:
-      "An emotion-tracking app built around a single idea: what if you could see your year in color? Check in during the day, tag how you feel, and watch your calendar fill with color over time. Each emotion maps to a hue — warm for high-energy, cool for calm — building a visual canvas of your emotional life. Mosaic also surfaces insights: patterns you wouldn't notice on your own, surfaced quietly.",
-    tech: 'React Native, Expo, TypeScript, Unistyles',
-    slug: 'mosaic',
-    links: [
-      {
-        label: 'Live Site',
-        url: 'https://www.yubico.com/quiz/',
-        type: 'web',
-      },
-      {
-        label: 'Read Case Study',
-        to: '/projects/yubico-quiz',
-        type: 'case-study',
-        internal: true,
-      },
-    ],
-  },
+  // {
+  //   title: 'Product Finder Quiz',
+  //   image:
+  //     'https://los-project-images.s3.us-east-1.amazonaws.com/portfolio/mosaic.webp',
+  //   description:
+  //     "An emotion-tracking app built around a single idea: what if you could see your year in color? Check in during the day, tag how you feel, and watch your calendar fill with color over time. Each emotion maps to a hue — warm for high-energy, cool for calm — building a visual canvas of your emotional life. Mosaic also surfaces insights: patterns you wouldn't notice on your own, surfaced quietly.",
+  //   tech: 'React Native, Expo, TypeScript, Unistyles',
+  //   slug: 'mosaic',
+  //   links: [
+  //     {
+  //       label: 'Live Site',
+  //       url: 'https://www.yubico.com/quiz/',
+  //       type: 'web',
+  //     },
+  //     {
+  //       label: 'Read Case Study',
+  //       to: '/projects/yubico-quiz',
+  //       type: 'case-study',
+  //       internal: true,
+  //     },
+  //   ],
+  // },
   {
     title: 'Los Zine',
     image:

--- a/src/portfolio-data.ts
+++ b/src/portfolio-data.ts
@@ -65,7 +65,7 @@ export const projects: Project[] = [
     ],
   },
   {
-    title: 'Yubico Quiz',
+    title: 'Product Finder Quiz',
     image:
       'https://los-project-images.s3.us-east-1.amazonaws.com/portfolio/mosaic.webp',
     description:
@@ -304,8 +304,8 @@ export const fullProjects: Project[] = [
     ],
   },
   {
-    title: 'Yubico Quiz',
-    slug: 'yubico-quiz',
+    title: 'Product Finder Quiz',
+    slug: 'product-finder-quiz',
     image:
       'https://los-project-images.s3.us-east-1.amazonaws.com/portfolio/mosaic.webp',
     description: '',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new case study page for the Yubico Product Finder Quiz, including full page content and live-site metadata.
  * Registered the case study in the portfolio so it appears alongside existing projects.

* **Enhancements**
  * Updated the case study footer to support a more compact link layout for select case studies.
  * Refined portfolio project naming to better match the updated case study title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->